### PR TITLE
Add send methods with headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,10 +69,11 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
-            <KAFKA_SERVICE_HOST>localhost:9092</KAFKA_SERVICE_HOST>
+            <KAFKA_SERVICE_HOST>localhost:9098</KAFKA_SERVICE_HOST>
           </systemPropertyVariables>
           <environmentVariables>
-            <TOPIC_NAME>ServiceInjectionTest</TOPIC_NAME>
+            <SIMPLE_TOPIC_NAME>ServiceInjectionTest.SimpleProducer</SIMPLE_TOPIC_NAME>
+            <EXTENDED_TOPIC_NAME>ServiceInjectionTest.ExtendedProducer</EXTENDED_TOPIC_NAME>
             <GROUP_ID>ServiceInjectionTest_annotation</GROUP_ID>
           </environmentVariables>
         </configuration>
@@ -150,8 +151,27 @@
       <scope>test</scope>
     </dependency>
 
+      <dependency>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-library</artifactId>
+          <version>1.3</version>
+      </dependency>
+  <dependency>
+      <groupId>org.ff4j</groupId>
+      <artifactId>ff4j-core</artifactId>
+      <version>1.7.1</version>
+      <scope>test</scope>
+  </dependency>
 
-    <dependency>
+  <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
+      <scope>test</scope>
+  </dependency>
+
+
+      <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>2.8.47</version>

--- a/src/main/java/org/aerogear/kafka/ExtendedKafkaProducer.java
+++ b/src/main/java/org/aerogear/kafka/ExtendedKafkaProducer.java
@@ -1,0 +1,15 @@
+package org.aerogear.kafka;
+
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+import java.util.Map;
+import java.util.concurrent.Future;
+
+public interface ExtendedKafkaProducer<K, V>  extends SimpleKafkaProducer<K, V> {
+
+    Future<RecordMetadata> send(String topic, V payload, Map<String, byte[]> headers);
+    Future<RecordMetadata> send(String topic, V payload, Map<String, byte[]> headers, Callback callback);
+    Future<RecordMetadata> send(String topic, K key, V payload, Map<String, byte[]> headers);
+    Future<RecordMetadata> send(String topic, K key, V payload, Map<String, byte[]> headers, Callback callback);
+}

--- a/src/test/java/org/aerogear/kafka/cdi/ServiceInjectionTest.java
+++ b/src/test/java/org/aerogear/kafka/cdi/ServiceInjectionTest.java
@@ -28,6 +28,9 @@ import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 @RunWith(Arquillian.class)
 public class ServiceInjectionTest extends KafkaClusterTestBase {
 
@@ -43,8 +46,12 @@ public class ServiceInjectionTest extends KafkaClusterTestBase {
     private KafkaService service;
 
     @Test
-    public void nonNullProducer() {
-        Assertions.assertThat(service.returnProducer()).isNotNull();
+    public void nonNullSimpleProducer() {
+        Assertions.assertThat(service.returnSimpleProducer()).isNotNull();
     }
 
+    @Test
+    public void nonNullExtendedProducer() {
+        assertThat(service.returnExtendedProducer(), notNullValue());
+    }
 }

--- a/src/test/java/org/aerogear/kafka/cdi/annotation/ForTopic.java
+++ b/src/test/java/org/aerogear/kafka/cdi/annotation/ForTopic.java
@@ -1,0 +1,16 @@
+package org.aerogear.kafka.cdi.annotation;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier
+public @interface ForTopic {
+    String value();
+}

--- a/src/test/java/org/aerogear/kafka/cdi/beans/KafkaService.java
+++ b/src/test/java/org/aerogear/kafka/cdi/beans/KafkaService.java
@@ -15,12 +15,17 @@
  */
 package org.aerogear.kafka.cdi.beans;
 
+import org.aerogear.kafka.ExtendedKafkaProducer;
+import org.aerogear.kafka.SimpleKafkaProducer;
 import org.aerogear.kafka.cdi.ReceiveMessageFromInjectedServiceTest;
 import org.aerogear.kafka.cdi.annotation.KafkaConfig;
-import org.aerogear.kafka.SimpleKafkaProducer;
 import org.aerogear.kafka.cdi.annotation.Producer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
 
 @KafkaConfig(bootstrapServers = "#{KAFKA_SERVICE_HOST}")
 public class KafkaService {
@@ -30,13 +35,27 @@ public class KafkaService {
     @Producer
     private SimpleKafkaProducer<Integer, String> producer;
 
-    public SimpleKafkaProducer returnProducer() {
+    @Producer
+    private ExtendedKafkaProducer<Integer, String> extendedKafkaProducer;
+
+    public SimpleKafkaProducer returnSimpleProducer() {
         return producer;
+    }
+
+    public ExtendedKafkaProducer returnExtendedProducer() {
+        return extendedKafkaProducer;
     }
 
     public void sendMessage() {
         logger.info("sending message to the topic....");
-        producer.send(ReceiveMessageFromInjectedServiceTest.TOPIC_NAME, "This is only a test");
+        producer.send(ReceiveMessageFromInjectedServiceTest.SIMPLE_PRODUCER_TOPIC_NAME, "This is only a test");
+    }
+
+    public void sendMessageWithHeader() {
+        logger.info("sending message with header to the topic....");
+        Map<String, byte[]> headers = new HashMap<>();
+        headers.put("header.key", "header.value".getBytes(Charset.forName("UTF-8")));
+        extendedKafkaProducer.send(ReceiveMessageFromInjectedServiceTest.EXTENDED_PRODUCER_TOPIC_NAME, "This is only a second test", headers);
     }
 
 }

--- a/src/test/java/org/aerogear/kafka/cdi/beans/mock/MockProvider.java
+++ b/src/test/java/org/aerogear/kafka/cdi/beans/mock/MockProvider.java
@@ -15,18 +15,30 @@
  */
 package org.aerogear.kafka.cdi.beans.mock;
 
+import org.aerogear.kafka.cdi.annotation.ForTopic;
 import org.mockito.Mockito;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 
+import static org.aerogear.kafka.cdi.ReceiveMessageFromInjectedServiceTest.EXTENDED_PRODUCER_TOPIC_NAME;
+import static org.aerogear.kafka.cdi.ReceiveMessageFromInjectedServiceTest.SIMPLE_PRODUCER_TOPIC_NAME;
+
 @ApplicationScoped
 public class MockProvider {
 
-    private MessageReceiver receiver = Mockito.mock(MessageReceiver.class);
+    private MessageReceiver simpleTopicReceiver = Mockito.mock(MessageReceiver.class);
+    private MessageReceiver extendedTopicReceiver = Mockito.mock(MessageReceiver.class);
 
     @Produces
-    public MessageReceiver receiver() {
-        return receiver;
+    @ForTopic(SIMPLE_PRODUCER_TOPIC_NAME)
+    public MessageReceiver simpleReceiver() {
+        return simpleTopicReceiver;
+    }
+
+    @Produces
+    @ForTopic(EXTENDED_PRODUCER_TOPIC_NAME)
+    public MessageReceiver extendedReceiver() {
+        return extendedTopicReceiver;
     }
 }

--- a/src/test/java/org/aerogear/kafka/cdi/tests/KafkaClusterTestBase.java
+++ b/src/test/java/org/aerogear/kafka/cdi/tests/KafkaClusterTestBase.java
@@ -42,7 +42,7 @@ public abstract class KafkaClusterTestBase extends AbstractTestBase {
         kafkaCluster = new KafkaCluster().usingDirectory(dataDir)
                 .deleteDataPriorToStartup(true)
                 .deleteDataUponShutdown(true)
-                .withPorts(2181, 9092);
+                .withPorts(2282, 9098);
         return kafkaCluster;
     }
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration debug="true">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are  by default assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
Added an Extended-Producer with the possibility to add Kafka-headers to the message.

Hint: I needed to change the default ports for Kafka to allow running a Kafka instance while testing this project without to stop Kafka before.