### PR TITLE
Ensuring correct key/value type when using headers in receiver method

### DIFF
--- a/src/main/java/org/aerogear/kafka/impl/DelegationKafkaConsumer.java
+++ b/src/main/java/org/aerogear/kafka/impl/DelegationKafkaConsumer.java
@@ -83,7 +83,7 @@ public class DelegationKafkaConsumer implements Runnable {
 
     private Class<?> consumerKeyType(final Class<?> defaultKeyType, final AnnotatedMethod annotatedMethod) {
 
-        if (annotatedMethod.getJavaMember().getParameterTypes().length == 2) {
+        if (annotatedMethod.getJavaMember().getParameterTypes().length >= 2) {
             return annotatedMethod.getJavaMember().getParameterTypes()[0];
         } else {
             return defaultKeyType;
@@ -92,7 +92,7 @@ public class DelegationKafkaConsumer implements Runnable {
 
     private Class<?> consumerValueType(final AnnotatedMethod annotatedMethod) {
 
-        if (annotatedMethod.getJavaMember().getParameterTypes().length == 2) {
+        if (annotatedMethod.getJavaMember().getParameterTypes().length >= 2) {
             return annotatedMethod.getJavaMember().getParameterTypes()[1];
         } else {
             return annotatedMethod.getJavaMember().getParameterTypes()[0];
@@ -149,7 +149,7 @@ public class DelegationKafkaConsumer implements Runnable {
 
                         if (annotatedListenerMethod.getJavaMember().getParameterTypes().length == 3) {
                             annotatedListenerMethod.getJavaMember().invoke(consumerInstance, record.key(), record.value(), record.headers());
-                        }else if (annotatedListenerMethod.getJavaMember().getParameterTypes().length == 2) {
+                        } else if (annotatedListenerMethod.getJavaMember().getParameterTypes().length == 2) {
                             annotatedListenerMethod.getJavaMember().invoke(consumerInstance, record.key(), record.value());
 
                         } else {

--- a/src/test/java/org/aerogear/kafka/cdi/ReceiveMessageFromInjectedServiceTest.java
+++ b/src/test/java/org/aerogear/kafka/cdi/ReceiveMessageFromInjectedServiceTest.java
@@ -28,6 +28,8 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -40,7 +42,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+
+import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -99,6 +104,8 @@ public class ReceiveMessageFromInjectedServiceTest extends KafkaClusterTestBase 
             }
         }
 
+        Thread.sleep(2000);
+
         Mockito.verify(receiver, Mockito.times(1)).ack();
     }
 
@@ -131,6 +138,11 @@ public class ReceiveMessageFromInjectedServiceTest extends KafkaClusterTestBase 
             }
         }
 
-        Mockito.verify(receiver, Mockito.times(1)).ack();
+        Thread.sleep(2000);
+
+        List<Header> headersList = Arrays.asList(new RecordHeader("header.key", "header.value".getBytes(Charset.forName("UTF-8"))));
+        RecordHeaders expectedHeaders = new RecordHeaders(headersList);
+
+        Mockito.verify(receiver, Mockito.times(1)).ack(42, "This is only a second test", expectedHeaders);
     }
 }

--- a/src/test/java/org/aerogear/kafka/cdi/beans/KafkaMessageListener.java
+++ b/src/test/java/org/aerogear/kafka/cdi/beans/KafkaMessageListener.java
@@ -61,8 +61,8 @@ public class KafkaMessageListener {
             groupId = "#{GROUP_ID}",
             consumerRebalanceListener = MyConsumerRebalanceListener.class
     )
-    public void onMessage(final String key, final String simplePayload, final Headers headers) {
+    public void onMessage(final Integer key, final String simplePayload, final Headers headers) {
         logger.info("Got message: {}||{}||{} ",key, simplePayload, headers);
-        extendedTopicReceiver.ack();
+        extendedTopicReceiver.ack(key, simplePayload, headers);
     }
 }

--- a/src/test/java/org/aerogear/kafka/cdi/beans/KafkaService.java
+++ b/src/test/java/org/aerogear/kafka/cdi/beans/KafkaService.java
@@ -55,7 +55,7 @@ public class KafkaService {
         logger.info("sending message with header to the topic....");
         Map<String, byte[]> headers = new HashMap<>();
         headers.put("header.key", "header.value".getBytes(Charset.forName("UTF-8")));
-        extendedKafkaProducer.send(ReceiveMessageFromInjectedServiceTest.EXTENDED_PRODUCER_TOPIC_NAME, "This is only a second test", headers);
+        extendedKafkaProducer.send(ReceiveMessageFromInjectedServiceTest.EXTENDED_PRODUCER_TOPIC_NAME, 42, "This is only a second test", headers);
     }
 
 }

--- a/src/test/java/org/aerogear/kafka/cdi/beans/mock/MessageReceiver.java
+++ b/src/test/java/org/aerogear/kafka/cdi/beans/mock/MessageReceiver.java
@@ -15,7 +15,11 @@
  */
 package org.aerogear.kafka.cdi.beans.mock;
 
+import org.apache.kafka.common.header.Headers;
+
 public interface MessageReceiver {
 
     void ack();
+
+    void ack(Integer key, String value, Headers expectedHeaders);
 }


### PR DESCRIPTION
Hey @matzew, I think this fix is needed for the header functionality in consumers.

Note that `ReceiveMessageFromInjectedServiceTest` is a bit unstable, it fails intermittently due to the mocks not being invoked. I'm not exactly sure why that is, perhaps the Kafka messages aren't received in the expected time?
