### PR TITLE
VerySimpleEnvironmentResolver now supports > 2 environment variables.

### DIFF
--- a/src/main/java/org/aerogear/kafka/cdi/extension/KafkaExtension.java
+++ b/src/main/java/org/aerogear/kafka/cdi/extension/KafkaExtension.java
@@ -80,7 +80,7 @@ public class KafkaExtension<X> implements Extension {
         // we just do the first
         if (kafkaConfig != null && bootstrapServers == null) {
             logger.info("setting bootstrap.servers IP for, {}", kafkaConfig.bootstrapServers());
-            bootstrapServers = VerySimpleEnvironmentResolver.simpleBootstrapServerResolver(kafkaConfig.bootstrapServers());
+            bootstrapServers = VerySimpleEnvironmentResolver.resolveVariables(kafkaConfig.bootstrapServers());
         }
     }
 

--- a/src/main/java/org/aerogear/kafka/cdi/extension/VerySimpleEnvironmentResolver.java
+++ b/src/main/java/org/aerogear/kafka/cdi/extension/VerySimpleEnvironmentResolver.java
@@ -15,43 +15,26 @@
  */
 package org.aerogear.kafka.cdi.extension;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class VerySimpleEnvironmentResolver {
+
+    //#{VARIABLE_NAME}
+    private static final Pattern PATTERN = Pattern.compile("(#[{]([^}]+)[}])");
 
     private VerySimpleEnvironmentResolver() {
         // no-op
     }
 
-    //#{KAFKA_SERVICE_HOST}:#{KAFKA_SERVICE_PORT}
-
-    public static String simpleBootstrapServerResolver(final String rawExpression) {
-
-        if (rawExpression.startsWith("#{")) {
-
-            final List<String> expressionParts = Arrays.asList(rawExpression.split(":"));
-
-            final List<String> variables = expressionParts.stream()
-                    .map(expression -> (expression.substring(2, expression.length() - 1)))
-                    .collect(Collectors.toList());
-
-            // check if we have host:port or just one variable:
-            if (variables.size() == 1) {
-                return resolve(variables.get(0));
-            } else if (variables.size() == 2) {
-                // we have host:port
-                final StringBuilder sb = new StringBuilder()
-                        .append(resolve(variables.get(0)))
-                        .append(":")
-                        .append(resolve(variables.get(1)));
-
-                return sb.toString();
-            }
+    //#{KAFKA_SERVICE_HOST}:#{KAFKA_SERVICE_PORT} --> localhost:9090
+    public static String resolveVariables(final String rawExpression) {
+        Matcher m = PATTERN.matcher(rawExpression);
+        String result = rawExpression;
+        while (m.find()) {
+            result = result.replace(m.group(1), resolve(m.group(2)));
         }
-        return rawExpression;
-
+        return result;
     }
 
     private static String resolve(final String variable) {

--- a/src/main/java/org/aerogear/kafka/impl/DelegationKafkaConsumer.java
+++ b/src/main/java/org/aerogear/kafka/impl/DelegationKafkaConsumer.java
@@ -108,10 +108,10 @@ public class DelegationKafkaConsumer implements Runnable {
         final Consumer consumerAnnotation = annotatedMethod.getAnnotation(Consumer.class);
 
         this.topics = Arrays.stream(consumerAnnotation.topics())
-                .map(VerySimpleEnvironmentResolver::simpleBootstrapServerResolver)
+                .map(VerySimpleEnvironmentResolver::resolveVariables)
                 .collect(Collectors.toList());
 
-        final String groupId = VerySimpleEnvironmentResolver.simpleBootstrapServerResolver(consumerAnnotation.groupId());
+        final String groupId = VerySimpleEnvironmentResolver.resolveVariables(consumerAnnotation.groupId());
         final Class<?> recordKeyType = consumerAnnotation.keyType();
 
         this.annotatedListenerMethod = annotatedMethod;

--- a/src/test/java/org/aerogear/kafka/cdi/extension/ResolverTest.java
+++ b/src/test/java/org/aerogear/kafka/cdi/extension/ResolverTest.java
@@ -34,26 +34,34 @@ public class ResolverTest {
     @Test
     public void resolveSingleExpression() {
 
-    final String resolvedURI = VerySimpleEnvironmentResolver.simpleBootstrapServerResolver("#{SINGLE}");
-    assertThat(resolvedURI).isEqualTo("localhost:9092");
+        final String resolvedURI = VerySimpleEnvironmentResolver.resolveVariables("#{SINGLE}");
+        assertThat(resolvedURI).isEqualTo("localhost:9092");
 
     }
 
     @Test
     public void resolveDoubleExpression() {
 
-        final String resolvedURI = VerySimpleEnvironmentResolver.simpleBootstrapServerResolver("#{MY_HOST}:#{MY_PORT}");
+        final String resolvedURI = VerySimpleEnvironmentResolver.resolveVariables("#{MY_HOST}:#{MY_PORT}");
         assertThat(resolvedURI).isEqualTo("localhost:9092");
     }
 
     @Test
+    public void resolveMultipleExpressions() {
+
+        final String resolvedURI = VerySimpleEnvironmentResolver.resolveVariables("This connects to host #{MY_HOST} port #{MY_PORT}, same as #{MY_PORT}");
+        assertThat(resolvedURI).isEqualTo("This connects to host localhost port 9092, same as 9092");
+    }
+
+
+    @Test
     public void resolveNoExpression() {
-        final String resolvedURI = VerySimpleEnvironmentResolver.simpleBootstrapServerResolver("localhost:9092");
+        final String resolvedURI = VerySimpleEnvironmentResolver.resolveVariables("localhost:9092");
         assertThat(resolvedURI).isEqualTo("localhost:9092");
     }
 
     @Test(expected = RuntimeException.class)
     public void canNotResolve() {
-        VerySimpleEnvironmentResolver.simpleBootstrapServerResolver("#{LOL}");
+        VerySimpleEnvironmentResolver.resolveVariables("#{LOL}");
     }
 }


### PR DESCRIPTION
## Motivation
We want to use variables in topics or group ids as prefixes, based on e.g. stage names.

Example:
```!java
@Consumer(
            topics = "#{NAMESPACE}-topic",
           ...)
```

## What
VerySimpleEnvironmentResolver now supports > 2 environment variables, and in all places.
Also renamed the method because it is used for more than just resolving the bootstrap server URL.

## Why
See motivation.

## How
The old implementation was replaced by a solution that uses regex parsing and replacing found matches by the configured environment variables. 

## Verification Steps

Unit test added.

## Checklist:

- [x] Code has been tested locally by PR requester
- [] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
