### PR TITLE
Kafkacloud

### DIFF
--- a/src/main/java/org/aerogear/kafka/cdi/annotation/KafkaAdditionalConfig.java
+++ b/src/main/java/org/aerogear/kafka/cdi/annotation/KafkaAdditionalConfig.java
@@ -16,21 +16,17 @@
 package org.aerogear.kafka.cdi.annotation;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 
 /**
- * Global configuration annotation. Only first occurrence will be used.
+ * Additional configuration annotation. Specifcy custom configuration for {@link KafkaConfig}.
  */
 @Inherited
-@Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface KafkaConfig {
-    String bootstrapServers();
-
-    KafkaAdditionalConfig[] additionalConfig() default {};
+public @interface KafkaAdditionalConfig {
+    String key();
+    String value();
 }

--- a/src/main/java/org/aerogear/kafka/cdi/extension/KafkaExtension.java
+++ b/src/main/java/org/aerogear/kafka/cdi/extension/KafkaExtension.java
@@ -243,12 +243,13 @@ public class KafkaExtension<X> implements Extension {
     }
 
     private org.apache.kafka.clients.producer.Producer createInjectionProducer(final String bootstrapServers, final Class<?> keySerializerClass, final Class<?> valSerializerClass, final Serializer<?> keySerializer, final Serializer<?> valSerializer ) {
-
-        final Properties properties = new Properties(additionalConfig);
+        final Properties properties = new Properties();
 
         properties.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         properties.put(KEY_SERIALIZER_CLASS_CONFIG, keySerializerClass);
         properties.put(VALUE_SERIALIZER_CLASS_CONFIG, valSerializerClass);
+
+        properties.putAll(additionalConfig);
 
         return new InjectedKafkaProducer(properties, keySerializer, valSerializer);
     }

--- a/src/main/java/org/aerogear/kafka/cdi/extension/KafkaExtension.java
+++ b/src/main/java/org/aerogear/kafka/cdi/extension/KafkaExtension.java
@@ -126,7 +126,7 @@ public class KafkaExtension<X> implements Extension {
             final DelegationKafkaConsumer frameworkConsumer = (DelegationKafkaConsumer) bm.getReference(bean, DelegationKafkaConsumer.class, ctx);
 
             // hooking it all together
-            frameworkConsumer.initialize(bootstrapServers, consumerMethod, bm);
+            frameworkConsumer.initialize(bootstrapServers, consumerMethod, bm, additionalConfig);
 
             managedConsumers.add(frameworkConsumer);
             submitToExecutor(frameworkConsumer);

--- a/src/main/java/org/aerogear/kafka/cdi/extension/KafkaExtension.java
+++ b/src/main/java/org/aerogear/kafka/cdi/extension/KafkaExtension.java
@@ -64,6 +64,7 @@ import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_
 public class KafkaExtension<X> implements Extension {
 
     private String bootstrapServers = null;
+    private Properties additionalConfig = null;
     private final Set<AnnotatedMethod<?>> listenerMethods = newSetFromMap(new ConcurrentHashMap<>());
     private final Set<AnnotatedMethod<?>> streamProcessorMethods = newSetFromMap(new ConcurrentHashMap<>());
     private final Set<DelegationKafkaConsumer> managedConsumers = newSetFromMap(new ConcurrentHashMap<>());
@@ -81,6 +82,11 @@ public class KafkaExtension<X> implements Extension {
         if (kafkaConfig != null && bootstrapServers == null) {
             logger.info("setting bootstrap.servers IP for, {}", kafkaConfig.bootstrapServers());
             bootstrapServers = VerySimpleEnvironmentResolver.simpleBootstrapServerResolver(kafkaConfig.bootstrapServers());
+
+            additionalConfig = new Properties();
+            Arrays.stream(kafkaConfig.additionalConfig()).forEach(kafkaAdditionalConfig -> {
+                additionalConfig.put(kafkaAdditionalConfig.key(), kafkaAdditionalConfig.value());
+            });
         }
     }
 
@@ -238,7 +244,8 @@ public class KafkaExtension<X> implements Extension {
 
     private org.apache.kafka.clients.producer.Producer createInjectionProducer(final String bootstrapServers, final Class<?> keySerializerClass, final Class<?> valSerializerClass, final Serializer<?> keySerializer, final Serializer<?> valSerializer ) {
 
-        final Properties properties = new Properties();
+        final Properties properties = new Properties(additionalConfig);
+
         properties.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         properties.put(KEY_SERIALIZER_CLASS_CONFIG, keySerializerClass);
         properties.put(VALUE_SERIALIZER_CLASS_CONFIG, valSerializerClass);

--- a/src/main/java/org/aerogear/kafka/impl/DelegationKafkaConsumer.java
+++ b/src/main/java/org/aerogear/kafka/impl/DelegationKafkaConsumer.java
@@ -104,7 +104,7 @@ public class DelegationKafkaConsumer implements Runnable {
     }
 
 
-    public void initialize(final String bootstrapServers, final AnnotatedMethod annotatedMethod, final BeanManager beanManager) {
+    public void initialize(final String bootstrapServers, final AnnotatedMethod annotatedMethod, final BeanManager beanManager, Properties additionalConfig) {
         final Consumer consumerAnnotation = annotatedMethod.getAnnotation(Consumer.class);
 
         this.topics = Arrays.stream(consumerAnnotation.topics())
@@ -124,6 +124,8 @@ public class DelegationKafkaConsumer implements Runnable {
         properties.put(AUTO_OFFSET_RESET_CONFIG, consumerAnnotation.offset());
         properties.put(KEY_DESERIALIZER_CLASS_CONFIG,  CafdiSerdes.serdeFrom(keyTypeClass).deserializer().getClass());
         properties.put(VALUE_DESERIALIZER_CLASS_CONFIG,CafdiSerdes.serdeFrom(valTypeClass).deserializer().getClass());
+
+        properties.putAll(additionalConfig);
 
         createKafkaConsumer(keyTypeClass, valTypeClass, properties);
         this.consumerRebalanceListener = createConsumerRebalanceListener(consumerAnnotation.consumerRebalanceListener());


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9867

## What
Allows specification of additional properties on @KafkaConfig, so you can specify e.g. security parameters (which are for example needed to connect to Confluent Cloud)

## Why
To be able to connect to security protected Kafka clusters/Confluent Cloud

## How
Adding an optional array of additional configuration fields to KafkaConfig (@KafkaAdditionalConfig)

## Verification Steps
 
1. Connect to a security protected Kafka instance without additional settings (fails)
2. Update with security settings
3. Connect again (works)

## Checklist:

- [ X ] Code has been tested locally by PR requester
- [ X ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished additional config feature
