### PR TITLE
Added configuration options in consumer annotation.

### DIFF
--- a/src/main/java/org/aerogear/kafka/cdi/annotation/Consumer.java
+++ b/src/main/java/org/aerogear/kafka/cdi/annotation/Consumer.java
@@ -36,6 +36,8 @@ public @interface Consumer {
     String[] topics();
     String groupId();
     String offset() default "latest";
+    int sessionTimeout() default 10000;
+    String clientId() default "";
     Class<?> keyType() default String.class;
     Class<? extends ConsumerRebalanceListener> consumerRebalanceListener() default DefaultConsumerRebalanceListener.class;
 }

--- a/src/main/java/org/aerogear/kafka/impl/DelegationKafkaConsumer.java
+++ b/src/main/java/org/aerogear/kafka/impl/DelegationKafkaConsumer.java
@@ -46,6 +46,8 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.CLIENT_ID_CONFIG;
 
 public class DelegationKafkaConsumer implements Runnable {
 
@@ -122,6 +124,8 @@ public class DelegationKafkaConsumer implements Runnable {
         properties.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         properties.put(GROUP_ID_CONFIG, groupId);
         properties.put(AUTO_OFFSET_RESET_CONFIG, consumerAnnotation.offset());
+        properties.put(SESSION_TIMEOUT_MS_CONFIG, consumerAnnotation.sessionTimeout());
+        properties.put(CLIENT_ID_CONFIG, consumerAnnotation.clientId());
         properties.put(KEY_DESERIALIZER_CLASS_CONFIG,  CafdiSerdes.serdeFrom(keyTypeClass).deserializer().getClass());
         properties.put(VALUE_DESERIALIZER_CLASS_CONFIG,CafdiSerdes.serdeFrom(valTypeClass).deserializer().getClass());
 

--- a/src/main/java/org/aerogear/kafka/impl/DelegationKafkaConsumer.java
+++ b/src/main/java/org/aerogear/kafka/impl/DelegationKafkaConsumer.java
@@ -42,10 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.*;
 
 public class DelegationKafkaConsumer implements Runnable {
 
@@ -122,6 +119,8 @@ public class DelegationKafkaConsumer implements Runnable {
         properties.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         properties.put(GROUP_ID_CONFIG, groupId);
         properties.put(AUTO_OFFSET_RESET_CONFIG, consumerAnnotation.offset());
+        properties.put(SESSION_TIMEOUT_MS_CONFIG, consumerAnnotation.sessionTimeout());
+        properties.put(CLIENT_ID_CONFIG, consumerAnnotation.clientId());
         properties.put(KEY_DESERIALIZER_CLASS_CONFIG,  CafdiSerdes.serdeFrom(keyTypeClass).deserializer().getClass());
         properties.put(VALUE_DESERIALIZER_CLASS_CONFIG,CafdiSerdes.serdeFrom(valTypeClass).deserializer().getClass());
 


### PR DESCRIPTION
## Motivation
We used this extension to consumer messages in an enterprise product. However, we needed to be able to handle messages for longer than 10 seconds. And preferably be able to set client identification also.

## What
I added optional consumer configuration for both clientId and sessionTimeout, which defaults to KafkaConsumers default values. 

## Why
There was no option to set it prior to this commit.

## How
See "what"

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Create a consumer with sessionTimeout 
2. If you have an instance of a logger the consumer logs the configurations it was started with.
3. Find SessionTimeoutMs and assure it is what you have set it to. 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
 

